### PR TITLE
test(deps): import google-cloud-pubsub-bom for test version management, update to 1.102.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,17 +168,13 @@
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
+      <!-- google-cloud-pubsub is used for testing -->
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-pubsub</artifactId>
-        <version>1.102.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-cloud-pubsub-v1</artifactId>
-        <version>1.84.0</version>
-        <scope>test</scope>
+        <artifactId>google-cloud-pubsub-bom</artifactId>
+        <version>1.102.1</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>


### PR DESCRIPTION
Replaces #38, #39 and in the future we won't receive 2 PRs when pubsub releases