### PR TITLE
deps: update dependency com.google.cloud:google-cloud-shared-dependencies to v0.20.1

### DIFF
--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -52,7 +52,7 @@ function completenessCheck() {
   # due to maven dependency plugin setting transitive compile/runtime deps scope to test when it is also a test dep
   # Raised issue: https://issues.apache.org/jira/browse/MDEP-737
   msg "Generating dependency list using flattened pom..."
-  mvn dependency:list -f .flattened-pom.xml -DincludeScope=runtime -DexcludeArtifactIds=annotations,gson,protobuf-java-util,commons-codec,commons-logging,perfmark-api -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
+  mvn dependency:list -f .flattened-pom.xml -DincludeScope=runtime -DexcludeArtifactIds=annotations,protobuf-java-util,commons-codec,commons-logging,perfmark-api -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
 
   # Compare two dependency lists
   msg "Comparing dependency lists..."

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>0.20.0</version>
+        <version>0.20.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
removing gson from the flattened-pom exclusion list as it is now back in the original pom list.
