### PR TITLE
fix: Exclude a few dependencies from dependency check.

### DIFF
--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -64,14 +64,14 @@ function completenessCheck() {
   # This is stripped from the output as it is not present in the flattened pom.
   # Only dependencies with 'compile' or 'runtime' scope are included from original dependency list.
   msg "Generating dependency list using original pom..."
-  mvn dependency:list -f pom.xml -DincludeScope=runtime -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e s/\\s--\\smodule.*// >.org-list.txt
+  mvn dependency:list -f pom.xml -DincludeScope=runtime -DexcludeArtifactIds=protobuf-java-util,grpc-services,re2j,opencensus-proto,bcpkix-jdk15on -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e s/\\s--\\smodule.*// >.org-list.txt
 
   # Output dep list generated using the flattened pom (only 'compile' and 'runtime' scopes)
   # [3/1/2021] Adding -DexcludeArtifactIds=annotations,gson,commons-codec,commons-logging,animal-sniffer-annotations
   # due to maven dependency plugin setting transitive compile/runtime deps scope to test when it is also a test dep
   # Raised issue: https://issues.apache.org/jira/browse/MDEP-737
   msg "Generating dependency list using flattened pom..."
-  mvn dependency:list -f .flattened-pom.xml -DincludeScope=runtime -DexcludeArtifactIds=annotations,commons-codec,commons-logging,animal-sniffer-annotations,bcprov-jdk15on -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
+  mvn dependency:list -f .flattened-pom.xml -DincludeScope=runtime -DexcludeArtifactIds=annotations,commons-codec,commons-logging,animal-sniffer-annotations,bcprov-jdk15on,protobuf-java-util,grpc-services,re2j,opencensus-proto,bcpkix-jdk15on -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
 
   # Compare two dependency lists
   msg "Comparing dependency lists..."


### PR DESCRIPTION
Exclude the following dependencies from dependency check since they are now test dependencies brought in transitively by `java-pubsub`.

grpc-services,
re2j,
opencensus-proto,
bcpkix-jdk15on,
protobuf-java-util